### PR TITLE
Atlassian has changed API endpoint for fetching tickets

### DIFF
--- a/src/activate.js
+++ b/src/activate.js
@@ -80,11 +80,20 @@ async function activate(context) {
 
                 if (cachedIssues) return cachedIssues;
                 // get list of tickets assigned to current user from JIRA using axios
-                const { data: { issues } } = await axios.get(CONSTANTS.url(baseUrl), {
-                    headers: {
-                        Authorization: `Basic ${secrets}`,
+                const { data: { issues } } = await axios.post(CONSTANTS.url(baseUrl),
+                    {
+                        jql: "updated >= -20d AND assignee in (currentUser()) order by updated DESC",
+                        maxResults: 15,
+                        fields: ["key", "summary", "updated"]
+                    },
+                    {
+                        headers: {
+                            Authorization: `Basic ${secrets}`,
+                            Accept: "application/json",
+                            "Content-Type": "application/json"
+                        }
                     }
-                });
+                );
 
                 return issues.map(issue => ({
                     label: `${issue.fields.summary}`,

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,7 +17,7 @@ const CONSTANTS = {
         '📒 Documentation',
         '🔂 Revert'
     ],
-    url: (baseURL) => `${baseURL.replace(/\/$/, '')}/rest/api/latest/search/?jql=updated >= -20d AND assignee in (currentUser()) order by updated DESC&maxResults=15`,
+    url: (baseURL) => `${baseURL.replace(/\/$/, '')}/rest/api/3/search/jql`,
     strings: {
         usernamePlaceholder: 'Enter your JIRA email (eg: your-name@your-company.com)',
         tokenPlaceholder: 'Enter your JIRA API token',


### PR DESCRIPTION
## Summary

This pull request updates the Jira API integration in the extension to comply with the latest Atlassian Cloud changes. The previous implementation relied on `GET /rest/api/latest/search?jql=...`, which has been **removed** by Atlassian (see [[changelog](https://developer.atlassian.com/changelog/#CHANGE-2046)](https://developer.atlassian.com/changelog/#CHANGE-2046)).

The new API requires using `POST /rest/api/3/search/jql` with the JQL query provided in the request body.

---

## Changes

* Replaced `axios.get(CONSTANTS.url(baseUrl), …)` with a `POST` request to `${baseUrl}/rest/api/3/search/jql`.
* Moved the JQL query and `maxResults` into the request body, as required by the new endpoint.
* Added explicit request headers (`Accept` and `Content-Type`) to align with Atlassian’s API specification.
* Limited returned fields to `key`, `summary`, and `updated` to reduce payload size.

---

## Motivation

Without this change, the extension fails to fetch issues from Jira Cloud because the old endpoint returns:

```json
{
  "errorMessages": [
    "The requested API has been removed. Please migrate to the /rest/api/3/search/jql API."
  ],
  "errors": {}
}
```

This update restores compatibility with Jira Cloud instances and ensures that users can continue fetching their assigned tickets.

---

## Testing

* Verified against a Jira Cloud instance (`atlassian.net`) using API tokens.
* Confirmed that issues are returned and mapped correctly into the extension’s quick pick list.

---

## Notes

* This change only affects Jira Cloud users. Jira Server/DC users (who still support `GET /rest/api/2/search`) may require separate handling if backward compatibility is a concern.
* Documentation updates may be needed to reflect the new API usage.
